### PR TITLE
Reorganize, clarify document

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,157 +3,174 @@
 For an explainer on how to comment on the framework, see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Proposals
+## Table of Contents
 
-1. ### Regulate Digital Assets Under a Separate Framework
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-    1. Define **_"digital asset"_** as:
+- [Framework](#framework)
+  - [1. Regulate Digital Assets Under a Separate Framework](#1-regulate-digital-assets-under-a-separate-framework)
+  - [2. Designate One Regulator for Digital Asset Markets](#2-designate-one-regulator-for-digital-asset-markets)
+  - [3. Promote Interoperability and Fair Competition](#3-promote-interoperability-and-fair-competition)
+- [Goals](#goals)
+  - [1. Enhance transparency through appropriate disclosure requirements](#1-enhance-transparency-through-appropriate-disclosure-requirements)
+  - [2. Protect against fraud and market manipulation](#2-protect-against-fraud-and-market-manipulation)
+  - [3. Promote efficiency and strengthen market resiliency](#3-promote-efficiency-and-strengthen-market-resiliency)
 
-        > A financial asset issued and transferred using distributed ledger or
-        > blockchain technology.
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-        **_"Financial asset"_** would include an asset whose primary use is as a
-        payment instrument, medium of exchange, means of storing value, or
-        otherwise as a financial interest.
 
-    2. In creating a new regulatory framework for digital assets, Congress
-       should recognize in law that all digital assets, including digitally
-       native versions of traditional financial assets, should be subject to a
-       new regulatory regime for digital assets.
+## Framework
 
-2. ### Designate One Regulator for Digital Asset Markets
+### 1. Regulate Digital Assets Under a Separate Framework
 
-    1. Authority would include:
+1. Define **_"digital asset"_** as:
 
-        1. A new registration process established for marketplaces for digital
-            assets (**_"MDAs"_**).
+    > A financial asset issued and transferred using distributed ledger or
+    > blockchain technology.
 
-        2. Appropriate disclosures to inform purchasers of digital assets.
+    **_"Financial asset"_** would include an asset whose primary use is as a
+    payment instrument, medium of exchange, means of storing value, or
+    otherwise as a financial interest.
 
-    2. MDA regulation should support the efficiency benefits of
-       straight-through-processing.
+2. In creating a new regulatory framework for digital assets, Congress
+    should recognize in law that all digital assets, including digitally
+    native versions of traditional financial assets, should be subject to a
+    new regulatory regime for digital assets.
 
-    3. MDAs should be authorized to perform the full lifecycle of digital asset
-       services, including digital asset trading, transfer (e.g., wallet
-       services), custody, clearing, money payment, staking, borrowing and
-       lending, and related incidental services.
+### 2. Designate One Regulator for Digital Asset Markets
 
-    4. The regulator should be authorized to offer different registration paths
-       for different kinds of MDAs depending on the scope of activities they
-       provide.
+1. Authority would include:
 
-    5. Regulations should focus on equal and open access to digital asset
-       trading for all market participants — retail and institutional.
+    1. A new registration process established for marketplaces for digital
+        assets (**_"MDAs"_**).
 
-    6. A dedicated self-regulatory organization (**"_SRO"_**) should be
-       established to strengthen the oversight regime and provide more granular
-       oversight of MDAs.
+    2. Appropriate disclosures to inform purchasers of digital assets.
 
-        1. All registered MDAs should be required to be members of the SRO.
+2. MDA regulation should support the efficiency benefits of
+    straight-through-processing.
 
-        2. The SRO should establish the self-certification process that an MDA
-            would use to make a digital asset available for trading on its
-            platform.
+3. MDAs should be authorized to perform the full lifecycle of digital asset
+    services, including digital asset trading, transfer (e.g., wallet
+    services), custody, clearing, money payment, staking, borrowing and
+    lending, and related incidental services.
 
-    7. The framework would preempt state-by-state registration and related
-       regulatory requirements.
+4. The regulator should be authorized to offer different registration paths
+    for different kinds of MDAs depending on the scope of activities they
+    provide.
 
-    8. The treatment of platforms and services that do not custody or otherwise
-       control the assets of a customer would need to be inherently different
-       from an MDA that holds and controls customer assets, and is therefore not
-       addressed by this framework.
+5. Regulations should focus on equal and open access to digital asset
+    trading for all market participants — retail and institutional.
 
-6. ### Promote Interoperability and Fair Competition
+6. A dedicated self-regulatory organization (**"_SRO"_**) should be
+    established to strengthen the oversight regime and provide more granular
+    oversight of MDAs.
 
-    1. MDAs must be interoperable with products and services across the
-       cryptoeconomy.
+    1. All registered MDAs should be required to be members of the SRO.
 
-    2. The new regulatory framework should encourage communication, competition
-       and cross-pollination among protocols, applications, and MDAs.
+    2. The SRO should establish the self-certification process that an MDA
+        would use to make a digital asset available for trading on its
+        platform.
 
-## Framework Goals
+7. The framework would preempt state-by-state registration and related
+    regulatory requirements.
 
-1. ### Enhance transparency through appropriate disclosure requirements
+8. The treatment of platforms and services that do not custody or otherwise
+    control the assets of a customer would need to be inherently different
+    from an MDA that holds and controls customer assets, and is therefore not
+    addressed by this framework.
 
-   1. The information environment for digital assets should focus on the
-      material characteristics, benefits, and risks of the asset itself. An
-      asset-centric approach would include information about the features of
-      underlying projects that investors are likely to find most relevant in
-      their purchase or use decisions.
+### 3. Promote Interoperability and Fair Competition
 
-      1. For digital assets that are debt or equity securities, many of the
-         current securities disclosure requirements may be appropriate.
+1. MDAs must be interoperable with products and services across the
+    cryptoeconomy.
 
-      2. Digital assets that are well-established, broadly understood, and
-         decentralized, like Bitcoin and Ether, should not require ongoing
-         disclosure.
+2. The new regulatory framework should encourage communication, competition
+    and cross-pollination among protocols, applications, and MDAs.
 
-      3. Digital tokens that are earlier in the life cycle, and not yet
-         decentralized, should have a minimum set of disclosures. For example,
-         those could be based on key features of the white papers that are
-         already widely used by the industry.
+## Goals
 
-      4. Asset-backed tokens, like stablecoins and other digital assets that are
-         pegged to a particular value or fiat currency and maintain a reserve of
-         assets designed to ensure they maintain the peg, require a different
-         type of disclosure. The disclosures should be appropriate to how they
-         are being used, which is inherently different from money market funds.
+### 1. Enhance transparency through appropriate disclosure requirements
 
-   2. Disclosure requirements must be flexible, so they can be readily applied
-      to a wide range of digital assets and so they are resilient in the face of
-      future innovation.
+1. The information environment for digital assets should focus on the
+  material characteristics, benefits, and risks of the asset itself. An
+  asset-centric approach would include information about the features of
+  underlying projects that investors are likely to find most relevant in
+  their purchase or use decisions.
 
-      1. The assigned federal regulator — together with the new SRO — must also
-         take a flexible and nimble approach with the disclosure requirements
-         rules that the information environment applied in practice.
+  1. For digital assets that are debt or equity securities, many of the
+      current securities disclosure requirements may be appropriate.
 
-      2. Where additional guidance is needed, there should be a straightforward
-         process for obtaining timely, case-specific, interpretive, or exemptive
-         relief.
+  2. Digital assets that are well-established, broadly understood, and
+      decentralized, like Bitcoin and Ether, should not require ongoing
+      disclosure.
 
-2. ### Protect against fraud and market manipulation
+  3. Digital tokens that are earlier in the life cycle, and not yet
+      decentralized, should have a minimum set of disclosures. For example,
+      those could be based on key features of the white papers that are
+      already widely used by the industry.
 
-   1. An MDA would need to make available required disclosures about the digital
-      assets it supports.
+  4. Asset-backed tokens, like stablecoins and other digital assets that are
+      pegged to a particular value or fiat currency and maintain a reserve of
+      assets designed to ensure they maintain the peg, require a different
+      type of disclosure. The disclosures should be appropriate to how they
+      are being used, which is inherently different from money market funds.
 
-   2. It should establish requirements and mechanisms for executing transactions
-      on MDA platforms, including for order book matching.
+2. Disclosure requirements must be flexible, so they can be readily applied
+  to a wide range of digital assets and so they are resilient in the face of
+  future innovation.
 
-   3. The MDA should have the ability to monitor trading activity on its
-      platforms and to enforce its trading requirements.
+  1. The assigned federal regulator — together with the new SRO — must also
+      take a flexible and nimble approach with the disclosure requirements
+      rules that the information environment applied in practice.
 
-   4. MDAs should provide clear information about their operations to the
-      public.
+  2. Where additional guidance is needed, there should be a straightforward
+      process for obtaining timely, case-specific, interpretive, or exemptive
+      relief.
 
-3. ### Promote efficiency and strengthen market resiliency
+### 2. Protect against fraud and market manipulation
 
-    Each of the goals should be accomplished in recognition of the unique
-    characteristics and risks of the underlying functionalities of digital
-    assets.
+1. An MDA would need to make available required disclosures about the digital
+  assets it supports.
 
-   1. Rules for MDAs should account for market participants having direct access
-      to exchange services, and not through broker-dealers as gatekeepers.
+2. It should establish requirements and mechanisms for executing transactions
+  on MDA platforms, including for order book matching.
 
-   2. The regulations should prescribe baseline requirements around cyber and
-      operational integrity and resiliency.
+3. The MDA should have the ability to monitor trading activity on its
+  platforms and to enforce its trading requirements.
 
-   3. They should include requirements for post-trade transparency of material
-      terms of digital asset transactions conducted on the platform.
+4. MDAs should provide clear information about their operations to the
+  public.
 
-   4. Rules should include requirements for asset safekeeping and use, to
-      address financial stability by requiring MDAs to maintain adequate capital
-      and liquidity, to facilitate customer portability, to promote
-      interoperability, and provide clear disclosures regarding the services
-      provided and associated fees.
+### 3. Promote efficiency and strengthen market resiliency
 
-   5. MDAs would be required to implement a compliance program, including
-      coverage of BSA AML requirements. Appropriately tailored customer
-      identification, transaction monitoring, SAR filing requirements, and OFAC
-      and sanctions screening obligations should all remain as available
-      resources.
+Each of the goals should be accomplished in recognition of the unique
+characteristics and risks of the underlying functionalities of digital
+assets.
 
-   6. MDAs should be required to mitigate and disclose potential conflicts of
-      interest.
+1. Rules for MDAs should account for market participants having direct access
+  to exchange services, and not through broker-dealers as gatekeepers.
 
-   7. MDAs must also consider and address risks arising from the role played by
-      market-makers and other liquidity providers on their trading venues.
+2. The regulations should prescribe baseline requirements around cyber and
+  operational integrity and resiliency.
+
+3. They should include requirements for post-trade transparency of material
+  terms of digital asset transactions conducted on the platform.
+
+4. Rules should include requirements for asset safekeeping and use, to
+  address financial stability by requiring MDAs to maintain adequate capital
+  and liquidity, to facilitate customer portability, to promote
+  interoperability, and provide clear disclosures regarding the services
+  provided and associated fees.
+
+5. MDAs would be required to implement a compliance program, including
+  coverage of BSA AML requirements. Appropriately tailored customer
+  identification, transaction monitoring, SAR filing requirements, and OFAC
+  and sanctions screening obligations should all remain as available
+  resources.
+
+6. MDAs should be required to mitigate and disclose potential conflicts of
+  interest.
+
+7. MDAs must also consider and address risks arising from the role played by
+  market-makers and other liquidity providers on their trading venues.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ For an explainer on how to comment on the framework, see
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Framework](#framework)
-  - [1. Regulate Digital Assets Under a Separate Framework](#1-regulate-digital-assets-under-a-separate-framework)
-  - [2. Designate One Regulator for Digital Asset Markets](#2-designate-one-regulator-for-digital-asset-markets)
-  - [3. Promote Interoperability and Fair Competition](#3-promote-interoperability-and-fair-competition)
+  - [1. Regulate Digital Assets Under a Separate
+    Framework](#1-regulate-digital-assets-under-a-separate-framework)
+  - [2. Designate One Regulator for Digital Asset
+    Markets](#2-designate-one-regulator-for-digital-asset-markets)
+  - [3. Promote Interoperability and Fair
+    Competition](#3-promote-interoperability-and-fair-competition)
 - [Goals](#goals)
-  - [1. Enhance transparency through appropriate disclosure requirements](#1-enhance-transparency-through-appropriate-disclosure-requirements)
-  - [2. Protect against fraud and market manipulation](#2-protect-against-fraud-and-market-manipulation)
-  - [3. Promote efficiency and strengthen market resiliency](#3-promote-efficiency-and-strengthen-market-resiliency)
+  - [1. Enhance transparency through appropriate disclosure
+    requirements](#1-enhance-transparency-through-appropriate-disclosure-requirements)
+  - [2. Protect against fraud and market
+    manipulation](#2-protect-against-fraud-and-market-manipulation)
+  - [3. Promote efficiency and strengthen market
+    resiliency](#3-promote-efficiency-and-strengthen-market-resiliency)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -24,19 +30,17 @@ For an explainer on how to comment on the framework, see
 
 ### 1. Regulate Digital Assets Under a Separate Framework
 
-1. Define **_"digital asset"_** as:
-
-    > A financial asset issued and transferred using distributed ledger or
-    > blockchain technology.
+1. Define **_"digital asset"_** as a financial asset issued and transferred
+   using distributed ledger or blockchain technology.
 
     **_"Financial asset"_** would include an asset whose primary use is as a
-    payment instrument, medium of exchange, means of storing value, or
-    otherwise as a financial interest.
+    payment instrument, medium of exchange, means of storing value, or otherwise
+    as a financial interest.
 
-2. In creating a new regulatory framework for digital assets, Congress
-    should recognize in law that all digital assets, including digitally
-    native versions of traditional financial assets, should be subject to a
-    new regulatory regime for digital assets.
+2. In creating a new regulatory framework for digital assets, Congress should
+    recognize in law that all digital assets, including digitally native
+    versions of traditional financial assets, should be subject to a new
+    regulatory regime for digital assets.
 
 ### 2. Designate One Regulator for Digital Asset Markets
 
@@ -51,33 +55,31 @@ For an explainer on how to comment on the framework, see
     straight-through-processing.
 
 3. MDAs should be authorized to perform the full lifecycle of digital asset
-    services, including digital asset trading, transfer (e.g., wallet
-    services), custody, clearing, money payment, staking, borrowing and
-    lending, and related incidental services.
+    services, including digital asset trading, transfer (e.g., wallet services),
+    custody, clearing, money payment, staking, borrowing and lending, and
+    related incidental services.
 
-4. The regulator should be authorized to offer different registration paths
-    for different kinds of MDAs depending on the scope of activities they
-    provide.
+4. The regulator should be authorized to offer different registration paths for
+    different kinds of MDAs depending on the scope of activities they provide.
 
-5. Regulations should focus on equal and open access to digital asset
-    trading for all market participants — retail and institutional.
+5. Regulations should focus on equal and open access to digital asset trading
+    for all market participants — retail and institutional.
 
-6. A dedicated self-regulatory organization (**"_SRO"_**) should be
-    established to strengthen the oversight regime and provide more granular
-    oversight of MDAs.
+6. A dedicated self-regulatory organization (**"_SRO"_**) should be established
+    to strengthen the oversight regime and provide more granular oversight of
+    MDAs.
 
     1. All registered MDAs should be required to be members of the SRO.
 
-    2. The SRO should establish the self-certification process that an MDA
-        would use to make a digital asset available for trading on its
-        platform.
+    2. The SRO should establish the self-certification process that an MDA would
+        use to make a digital asset available for trading on its platform.
 
 7. The framework would preempt state-by-state registration and related
     regulatory requirements.
 
 8. The treatment of platforms and services that do not custody or otherwise
-    control the assets of a customer would need to be inherently different
-    from an MDA that holds and controls customer assets, and is therefore not
+    control the assets of a customer would need to be inherently different from
+    an MDA that holds and controls customer assets, and is therefore not
     addressed by this framework.
 
 ### 3. Promote Interoperability and Fair Competition
@@ -85,21 +87,21 @@ For an explainer on how to comment on the framework, see
 1. MDAs must be interoperable with products and services across the
     cryptoeconomy.
 
-2. The new regulatory framework should encourage communication, competition
-    and cross-pollination among protocols, applications, and MDAs.
+2. The new regulatory framework should encourage communication, competition and
+    cross-pollination among protocols, applications, and MDAs.
 
 ## Goals
 
 ### 1. Enhance transparency through appropriate disclosure requirements
 
-1. The information environment for digital assets should focus on the
-  material characteristics, benefits, and risks of the asset itself. An
-  asset-centric approach would include information about the features of
-  underlying projects that investors are likely to find most relevant in
-  their purchase or use decisions.
+1. The information environment for digital assets should focus on the material
+   characteristics, benefits, and risks of the asset itself. An asset-centric
+   approach would include information about the features of underlying projects
+   that investors are likely to find most relevant in their purchase or use
+   decisions.
 
-  1. For digital assets that are debt or equity securities, many of the
-      current securities disclosure requirements may be appropriate.
+  1. For digital assets that are debt or equity securities, many of the current
+      securities disclosure requirements may be appropriate.
 
   2. Digital assets that are well-established, broadly understood, and
       decentralized, like Bitcoin and Ether, should not require ongoing
@@ -107,22 +109,22 @@ For an explainer on how to comment on the framework, see
 
   3. Digital tokens that are earlier in the life cycle, and not yet
       decentralized, should have a minimum set of disclosures. For example,
-      those could be based on key features of the white papers that are
-      already widely used by the industry.
+      those could be based on key features of the white papers that are already
+      widely used by the industry.
 
   4. Asset-backed tokens, like stablecoins and other digital assets that are
       pegged to a particular value or fiat currency and maintain a reserve of
-      assets designed to ensure they maintain the peg, require a different
-      type of disclosure. The disclosures should be appropriate to how they
-      are being used, which is inherently different from money market funds.
+      assets designed to ensure they maintain the peg, require a different type
+      of disclosure. The disclosures should be appropriate to how they are being
+      used, which is inherently different from money market funds.
 
-2. Disclosure requirements must be flexible, so they can be readily applied
-  to a wide range of digital assets and so they are resilient in the face of
-  future innovation.
+2. Disclosure requirements must be flexible, so they can be readily applied to a
+   wide range of digital assets and so they are resilient in the face of future
+   innovation.
 
-  1. The assigned federal regulator — together with the new SRO — must also
-      take a flexible and nimble approach with the disclosure requirements
-      rules that the information environment applied in practice.
+  1. The assigned federal regulator — together with the new SRO — must also take
+      a flexible and nimble approach with the disclosure requirements rules that
+      the information environment applied in practice.
 
   2. Where additional guidance is needed, there should be a straightforward
       process for obtaining timely, case-specific, interpretive, or exemptive
@@ -131,46 +133,43 @@ For an explainer on how to comment on the framework, see
 ### 2. Protect against fraud and market manipulation
 
 1. An MDA would need to make available required disclosures about the digital
-  assets it supports.
+   assets it supports.
 
-2. It should establish requirements and mechanisms for executing transactions
-  on MDA platforms, including for order book matching.
+2. It should establish requirements and mechanisms for executing transactions on
+   MDA platforms, including for order book matching.
 
-3. The MDA should have the ability to monitor trading activity on its
-  platforms and to enforce its trading requirements.
+3. The MDA should have the ability to monitor trading activity on its platforms
+   and to enforce its trading requirements.
 
-4. MDAs should provide clear information about their operations to the
-  public.
+4. MDAs should provide clear information about their operations to the public.
 
 ### 3. Promote efficiency and strengthen market resiliency
 
 Each of the goals should be accomplished in recognition of the unique
-characteristics and risks of the underlying functionalities of digital
-assets.
+characteristics and risks of the underlying functionalities of digital assets.
 
-1. Rules for MDAs should account for market participants having direct access
-  to exchange services, and not through broker-dealers as gatekeepers.
+1. Rules for MDAs should account for market participants having direct access to
+   exchange services, and not through broker-dealers as gatekeepers.
 
 2. The regulations should prescribe baseline requirements around cyber and
-  operational integrity and resiliency.
+   operational integrity and resiliency.
 
 3. They should include requirements for post-trade transparency of material
-  terms of digital asset transactions conducted on the platform.
+   terms of digital asset transactions conducted on the platform.
 
-4. Rules should include requirements for asset safekeeping and use, to
-  address financial stability by requiring MDAs to maintain adequate capital
-  and liquidity, to facilitate customer portability, to promote
-  interoperability, and provide clear disclosures regarding the services
-  provided and associated fees.
+4. Rules should include requirements for asset safekeeping and use, to address
+   financial stability by requiring MDAs to maintain adequate capital and
+   liquidity, to facilitate customer portability, to promote interoperability,
+   and provide clear disclosures regarding the services provided and associated
+   fees.
 
-5. MDAs would be required to implement a compliance program, including
-  coverage of BSA AML requirements. Appropriately tailored customer
-  identification, transaction monitoring, SAR filing requirements, and OFAC
-  and sanctions screening obligations should all remain as available
-  resources.
+5. MDAs would be required to implement a compliance program, including coverage
+   of BSA AML requirements. Appropriately tailored customer identification,
+   transaction monitoring, SAR filing requirements, and OFAC and sanctions
+   screening obligations should all remain as available resources.
 
 6. MDAs should be required to mitigate and disclose potential conflicts of
-  interest.
+   interest.
 
 7. MDAs must also consider and address risks arising from the role played by
-  market-makers and other liquidity providers on their trading venues.
+   market-makers and other liquidity providers on their trading venues.

--- a/README.md
+++ b/README.md
@@ -6,59 +6,59 @@ framework, or the framework as a whole, using GitHub. You will find it here:
 
 ## Regulate Digital Assets Under a Separate Framework
 
-- Define **_"digital asset"_** as:
+1. Define **_"digital asset"_** as:
 
-  > A financial asset issued and transferred using distributed ledger or
-  > blockchain technology.
+    > A financial asset issued and transferred using distributed ledger or
+    > blockchain technology.
 
-  **_"Financial asset"_** would include an asset whose primary use is as a
-  payment instrument, medium of exchange, means of storing value, or otherwise
-  as a financial interest.
+    **_"Financial asset"_** would include an asset whose primary use is as a
+    payment instrument, medium of exchange, means of storing value, or otherwise
+    as a financial interest.
 
-- In creating a new regulatory framework for digital assets, Congress should
-  recognize in law that all digital assets, including digitally native versions
-  of traditional financial assets, should be subject to a new regulatory regime
-  for digital assets.
+2. In creating a new regulatory framework for digital assets, Congress should
+   recognize in law that all digital assets, including digitally native versions
+   of traditional financial assets, should be subject to a new regulatory regime
+   for digital assets.
 
-## Designate One Regulator for Digital Asset Markets:
+## Designate One Regulator for Digital Asset Markets
 
-- Authority would include:
+1. Authority would include:
 
-  1. A new registration process established for marketplaces for digital assets
-     (**_"MDAs"_**).
+    1. A new registration process established for marketplaces for digital
+        assets (**_"MDAs"_**).
 
-  2. Appropriate disclosures to inform purchasers of digital assets.
+    2. Appropriate disclosures to inform purchasers of digital assets.
 
-- MDA regulation should support the efficiency benefits of
-  straight-through-processing.
+2. MDA regulation should support the efficiency benefits of
+   straight-through-processing.
 
-- MDAs should be authorized to perform the full lifecycle of digital asset
-  services, including digital asset trading, transfer (e.g., wallet services),
-  custody, clearing, money payment, staking, borrowing and lending, and related
-  incidental services.
+3. MDAs should be authorized to perform the full lifecycle of digital asset
+   services, including digital asset trading, transfer (e.g., wallet services),
+   custody, clearing, money payment, staking, borrowing and lending, and related
+   incidental services.
 
-- The regulator should be authorized to offer different registration paths for
-  different kinds of MDAs depending on the scope of activities they provide.
+4. The regulator should be authorized to offer different registration paths for
+   different kinds of MDAs depending on the scope of activities they provide.
 
-- Regulations should focus on equal and open access to digital asset trading for
-  all market participants — retail and institutional.
+5. Regulations should focus on equal and open access to digital asset trading
+   for all market participants — retail and institutional.
 
-- A dedicated self-regulatory organization (**"_SRO"_**) should be established
-  to strengthen the oversight regime and provide more granular oversight of
-  MDAs.
+6. A dedicated self-regulatory organization (**"_SRO"_**) should be established
+   to strengthen the oversight regime and provide more granular oversight of
+   MDAs.
 
-  1. All registered MDAs should be required to be members of the SRO.
+    1. All registered MDAs should be required to be members of the SRO.
 
-  2. The SRO should establish the self-certification process that an MDA would
-     use to make a digital asset available for trading on its platform.
+    2. The SRO should establish the self-certification process that an MDA would
+        use to make a digital asset available for trading on its platform.
 
-- The framework would preempt state-by-state registration and related regulatory
-  requirements.
+7. The framework would preempt state-by-state registration and related
+   regulatory requirements.
 
-- The treatment of platforms and services that do not custody or otherwise
-  control the assets of a customer would need to be inherently different from an
-  MDA that holds and controls customer assets, and is therefore not addressed by
-  this framework.
+8. The treatment of platforms and services that do not custody or otherwise
+   control the assets of a customer would need to be inherently different from
+   an MDA that holds and controls customer assets, and is therefore not
+   addressed by this framework.
 
 ## New Framework Should Be Guided by Three Goals
 
@@ -149,8 +149,8 @@ framework, or the framework as a whole, using GitHub. You will find it here:
 
 ## Promote Interoperability and Fair Competition
 
-- MDAs must be interoperable with products and services across the
-  cryptoeconomy.
+1. MDAs must be interoperable with products and services across the
+   cryptoeconomy.
 
-- The new regulatory framework should encourage communication, competition and
-  cross-pollination among protocols, applications, and MDAs.
+2. The new regulatory framework should encourage communication, competition and
+   cross-pollination among protocols, applications, and MDAs.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,156 @@
 # Operational Framework of the Digital Asset Policy Proposal
 
-We've created a simple explainer on how to comment on individual elements of the framework, or the framework as a whole, using GitHub.  You will find it here: [CONTRIBUTING.md](CONTRIBUTING.md)
+We've created a simple explainer on how to comment on individual elements of the
+framework, or the framework as a whole, using GitHub. You will find it here:
+[CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Regulate Digital Assets Under a Separate Framework
-* Define digital asset as: A financial asset issued and transferred using distributed ledger or blockchain technology. “Financial asset” would include an asset whose primary use is as a payment instrument, medium of exchange, means of storing value, or otherwise as a financial interest.
-* In creating a new regulatory framework for digital assets, Congress should recognize in law that all digital assets, including digitally native versions of traditional financial assets, should be subject to a new regulatory regime for digital assets.
+
+- Define **_"digital asset"_** as:
+
+  > A financial asset issued and transferred using distributed ledger or
+  > blockchain technology.
+
+  **_"Financial asset"_** would include an asset whose primary use is as a
+  payment instrument, medium of exchange, means of storing value, or otherwise
+  as a financial interest.
+
+- In creating a new regulatory framework for digital assets, Congress should
+  recognize in law that all digital assets, including digitally native versions
+  of traditional financial assets, should be subject to a new regulatory regime
+  for digital assets.
 
 ## Designate One Regulator for Digital Asset Markets:
-* Authority would include
-  1. A new registration process established for marketplaces for digital assets (MDAs).
+
+- Authority would include:
+
+  1. A new registration process established for marketplaces for digital assets
+     (**_"MDAs"_**).
+
   2. Appropriate disclosures to inform purchasers of digital assets.
-* MDA regulation should support the efficiency benefits of straight-through-processing.
-* MDAs should be authorized to perform the full lifecycle of digital asset services, including digital asset trading, transfer (e.g., wallet services), custody, clearing, money payment, staking, borrowing and lending, and related incidental services.
-* The regulator should be authorized to offer different registration paths for different kinds of MDAs depending on the scope of activities they provide.
-* Regulations should focus on equal and open access to digital asset trading for all market participants — retail and institutional.
-* A dedicated self-regulatory organization (SRO) should be established to strengthen the oversight regime and provide more granular oversight of MDAs.
+
+- MDA regulation should support the efficiency benefits of
+  straight-through-processing.
+
+- MDAs should be authorized to perform the full lifecycle of digital asset
+  services, including digital asset trading, transfer (e.g., wallet services),
+  custody, clearing, money payment, staking, borrowing and lending, and related
+  incidental services.
+
+- The regulator should be authorized to offer different registration paths for
+  different kinds of MDAs depending on the scope of activities they provide.
+
+- Regulations should focus on equal and open access to digital asset trading for
+  all market participants — retail and institutional.
+
+- A dedicated self-regulatory organization (**"_SRO"_**) should be established
+  to strengthen the oversight regime and provide more granular oversight of
+  MDAs.
+
   1. All registered MDAs should be required to be members of the SRO.
-  2. The SRO should establish the self-certification process that an MDA would use to make a digital asset available for trading on its platform.
-* The framework would preempt state-by-state registration and related regulatory requirements.
-* The treatment of platforms and services that do not custody or otherwise control the assets of a customer would need to be inherently different from an MDA that holds and controls customer assets, and is therefore not addressed by this framework.
+
+  2. The SRO should establish the self-certification process that an MDA would
+     use to make a digital asset available for trading on its platform.
+
+- The framework would preempt state-by-state registration and related regulatory
+  requirements.
+
+- The treatment of platforms and services that do not custody or otherwise
+  control the assets of a customer would need to be inherently different from an
+  MDA that holds and controls customer assets, and is therefore not addressed by
+  this framework.
 
 ## New Framework Should Be Guided by Three Goals
-1. Enhance transparency through appropriate disclosure requirements
-    1. The information environment for digital assets should focus on the material characteristics, benefits, and risks of the asset itself. An asset-centric approach would include information about the features of underlying projects that investors are likely to find most relevant in their purchase or use decisions.
-        1. For digital assets that are debt or equity securities, many of the current securities disclosure requirements may be appropriate.
-        2. Digital assets that are well-established, broadly understood, and decentralized, like Bitcoin and Ether, should not require ongoing disclosure.
-        3. Digital tokens that are earlier in the life cycle, and not yet decentralized, should have a minimum set of disclosures. For example, those could be based on key features of the white papers that are already widely used by the industry.
-        4. Asset-backed tokens, like stablecoins and other digital assets that are pegged to a particular value or fiat currency and maintain a reserve of assets designed to ensure they maintain the peg, require a different type of disclosure. The disclosures should be appropriate to how they are being used, which is inherently different from money market funds.
-    2. Disclosure requirements must be flexible, so they can be readily applied to a wide range of digital assets and so they are resilient in the face of future innovation.
-        1. The assigned federal regulator — together with the new SRO — must also take a flexible and nimble approach with the disclosure requirements rules that the information environment applied in practice.
-        2. Where additional guidance is needed, there should be a straightforward process for obtaining timely, case-specific, interpretive, or exemptive relief.
-2. Protect against fraud and market manipulation
-    1. An MDA would need to make available required disclosures about the digital assets it supports.
-    2. It should establish requirements and mechanisms for executing transactions on MDA platforms, including for order book matching.
-    3. The MDA should have the ability to monitor trading activity on its platforms and to enforce its trading requirements.
-    4. MDAs should provide clear information about their operations to the public.
-3. Promote efficiency and strengthen market resiliency
-    1. Rules for MDAs should account for market participants having direct access to exchange services, and not through broker-dealers as gatekeepers.
-    2. The regulations should prescribe baseline requirements around cyber and operational integrity and resiliency.
-    3. They should include requirements for post-trade transparency of material terms of digital asset transactions conducted on the platform.
-    4. Rules should include requirements for asset safekeeping and use, to address financial stability by requiring MDAs to maintain adequate capital and liquidity, to facilitate customer portability, to promote interoperability, and provide clear disclosures regarding the services provided and associated fees.
-    5. MDAs would be required to implement a compliance program, including coverage of BSA AML requirements. Appropriately tailored customer identification, transaction monitoring, SAR filing requirements, and OFAC and sanctions screening obligations should all remain as available resources.
-    6. MDAs should be required to mitigate and disclose potential conflicts of interest.
-    7. MDAs must also consider and address risks arising from the role played by market-makers and other liquidity providers on their trading venues.
-4. Each of the goals should be accomplished in recognition of the unique characteristics and risks of the underlying functionalities of digital assets.
 
+1. Enhance transparency through appropriate disclosure requirements
+
+   1. The information environment for digital assets should focus on the
+      material characteristics, benefits, and risks of the asset itself. An
+      asset-centric approach would include information about the features of
+      underlying projects that investors are likely to find most relevant in
+      their purchase or use decisions.
+
+      1. For digital assets that are debt or equity securities, many of the
+         current securities disclosure requirements may be appropriate.
+
+      2. Digital assets that are well-established, broadly understood, and
+         decentralized, like Bitcoin and Ether, should not require ongoing
+         disclosure.
+
+      3. Digital tokens that are earlier in the life cycle, and not yet
+         decentralized, should have a minimum set of disclosures. For example,
+         those could be based on key features of the white papers that are
+         already widely used by the industry.
+
+      4. Asset-backed tokens, like stablecoins and other digital assets that are
+         pegged to a particular value or fiat currency and maintain a reserve of
+         assets designed to ensure they maintain the peg, require a different
+         type of disclosure. The disclosures should be appropriate to how they
+         are being used, which is inherently different from money market funds.
+
+   2. Disclosure requirements must be flexible, so they can be readily applied
+      to a wide range of digital assets and so they are resilient in the face of
+      future innovation.
+
+      1. The assigned federal regulator — together with the new SRO — must also
+         take a flexible and nimble approach with the disclosure requirements
+         rules that the information environment applied in practice.
+
+      2. Where additional guidance is needed, there should be a straightforward
+         process for obtaining timely, case-specific, interpretive, or exemptive
+         relief.
+
+2. Protect against fraud and market manipulation
+
+   1. An MDA would need to make available required disclosures about the digital
+      assets it supports.
+
+   2. It should establish requirements and mechanisms for executing transactions
+      on MDA platforms, including for order book matching.
+
+   3. The MDA should have the ability to monitor trading activity on its
+      platforms and to enforce its trading requirements.
+
+   4. MDAs should provide clear information about their operations to the
+      public.
+
+3. Promote efficiency and strengthen market resiliency
+
+   1. Rules for MDAs should account for market participants having direct access
+      to exchange services, and not through broker-dealers as gatekeepers.
+
+   2. The regulations should prescribe baseline requirements around cyber and
+      operational integrity and resiliency.
+
+   3. They should include requirements for post-trade transparency of material
+      terms of digital asset transactions conducted on the platform.
+
+   4. Rules should include requirements for asset safekeeping and use, to
+      address financial stability by requiring MDAs to maintain adequate capital
+      and liquidity, to facilitate customer portability, to promote
+      interoperability, and provide clear disclosures regarding the services
+      provided and associated fees.
+
+   5. MDAs would be required to implement a compliance program, including
+      coverage of BSA AML requirements. Appropriately tailored customer
+      identification, transaction monitoring, SAR filing requirements, and OFAC
+      and sanctions screening obligations should all remain as available
+      resources.
+
+   6. MDAs should be required to mitigate and disclose potential conflicts of
+      interest.
+
+   7. MDAs must also consider and address risks arising from the role played by
+      market-makers and other liquidity providers on their trading venues.
+
+4. Each of the goals should be accomplished in recognition of the unique
+   characteristics and risks of the underlying functionalities of digital
+   assets.
 
 ## Promote Interoperability and Fair Competition
-* MDAs must be interoperable with products and services across the cryptoeconomy.
-* The new regulatory framework should encourage communication, competition and cross-pollination among protocols, applications, and MDAs.
+
+- MDAs must be interoperable with products and services across the
+  cryptoeconomy.
+
+- The new regulatory framework should encourage communication, competition and
+  cross-pollination among protocols, applications, and MDAs.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ framework, or the framework as a whole, using GitHub. You will find it here:
 
 ## New Framework Should Be Guided by Three Goals
 
-1. Enhance transparency through appropriate disclosure requirements
+### Enhance transparency through appropriate disclosure requirements
 
    1. The information environment for digital assets should focus on the
       material characteristics, benefits, and risks of the asset itself. An
@@ -100,7 +100,7 @@ framework, or the framework as a whole, using GitHub. You will find it here:
          process for obtaining timely, case-specific, interpretive, or exemptive
          relief.
 
-2. Protect against fraud and market manipulation
+### Protect against fraud and market manipulation
 
    1. An MDA would need to make available required disclosures about the digital
       assets it supports.
@@ -114,7 +114,7 @@ framework, or the framework as a whole, using GitHub. You will find it here:
    4. MDAs should provide clear information about their operations to the
       public.
 
-3. Promote efficiency and strengthen market resiliency
+### Promote efficiency and strengthen market resiliency
 
    1. Rules for MDAs should account for market participants having direct access
       to exchange services, and not through broker-dealers as gatekeepers.

--- a/README.md
+++ b/README.md
@@ -9,19 +9,13 @@ For an explainer on how to comment on the framework, see
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Framework](#framework)
-  - [1. Regulate Digital Assets Under a Separate
-    Framework](#1-regulate-digital-assets-under-a-separate-framework)
-  - [2. Designate One Regulator for Digital Asset
-    Markets](#2-designate-one-regulator-for-digital-asset-markets)
-  - [3. Promote Interoperability and Fair
-    Competition](#3-promote-interoperability-and-fair-competition)
+  - [1. Regulate Digital Assets Under a Separate Framework](#1-regulate-digital-assets-under-a-separate-framework)
+  - [2. Designate One Regulator for Digital Asset Markets](#2-designate-one-regulator-for-digital-asset-markets)
+  - [3. Promote Interoperability and Fair Competition](#3-promote-interoperability-and-fair-competition)
 - [Goals](#goals)
-  - [1. Enhance transparency through appropriate disclosure
-    requirements](#1-enhance-transparency-through-appropriate-disclosure-requirements)
-  - [2. Protect against fraud and market
-    manipulation](#2-protect-against-fraud-and-market-manipulation)
-  - [3. Promote efficiency and strengthen market
-    resiliency](#3-promote-efficiency-and-strengthen-market-resiliency)
+  - [1. Enhance transparency through appropriate disclosure requirements](#1-enhance-transparency-through-appropriate-disclosure-requirements)
+  - [2. Protect against fraud and market manipulation](#2-protect-against-fraud-and-market-manipulation)
+  - [3. Promote efficiency and strengthen market resiliency](#3-promote-efficiency-and-strengthen-market-resiliency)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,79 @@
 # Operational Framework of the Digital Asset Policy Proposal
 
-We've created a simple explainer on how to comment on individual elements of the
-framework, or the framework as a whole, using GitHub. You will find it here:
-[CONTRIBUTING.md](CONTRIBUTING.md)
+For an explainer on how to comment on the framework, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Regulate Digital Assets Under a Separate Framework
+## Proposals
 
-1. Define **_"digital asset"_** as:
+1. ### Regulate Digital Assets Under a Separate Framework
 
-    > A financial asset issued and transferred using distributed ledger or
-    > blockchain technology.
+    1. Define **_"digital asset"_** as:
 
-    **_"Financial asset"_** would include an asset whose primary use is as a
-    payment instrument, medium of exchange, means of storing value, or otherwise
-    as a financial interest.
+        > A financial asset issued and transferred using distributed ledger or
+        > blockchain technology.
 
-2. In creating a new regulatory framework for digital assets, Congress should
-   recognize in law that all digital assets, including digitally native versions
-   of traditional financial assets, should be subject to a new regulatory regime
-   for digital assets.
+        **_"Financial asset"_** would include an asset whose primary use is as a
+        payment instrument, medium of exchange, means of storing value, or
+        otherwise as a financial interest.
 
-## Designate One Regulator for Digital Asset Markets
+    2. In creating a new regulatory framework for digital assets, Congress
+       should recognize in law that all digital assets, including digitally
+       native versions of traditional financial assets, should be subject to a
+       new regulatory regime for digital assets.
 
-1. Authority would include:
+2. ### Designate One Regulator for Digital Asset Markets
 
-    1. A new registration process established for marketplaces for digital
-        assets (**_"MDAs"_**).
+    1. Authority would include:
 
-    2. Appropriate disclosures to inform purchasers of digital assets.
+        1. A new registration process established for marketplaces for digital
+            assets (**_"MDAs"_**).
 
-2. MDA regulation should support the efficiency benefits of
-   straight-through-processing.
+        2. Appropriate disclosures to inform purchasers of digital assets.
 
-3. MDAs should be authorized to perform the full lifecycle of digital asset
-   services, including digital asset trading, transfer (e.g., wallet services),
-   custody, clearing, money payment, staking, borrowing and lending, and related
-   incidental services.
+    2. MDA regulation should support the efficiency benefits of
+       straight-through-processing.
 
-4. The regulator should be authorized to offer different registration paths for
-   different kinds of MDAs depending on the scope of activities they provide.
+    3. MDAs should be authorized to perform the full lifecycle of digital asset
+       services, including digital asset trading, transfer (e.g., wallet
+       services), custody, clearing, money payment, staking, borrowing and
+       lending, and related incidental services.
 
-5. Regulations should focus on equal and open access to digital asset trading
-   for all market participants — retail and institutional.
+    4. The regulator should be authorized to offer different registration paths
+       for different kinds of MDAs depending on the scope of activities they
+       provide.
 
-6. A dedicated self-regulatory organization (**"_SRO"_**) should be established
-   to strengthen the oversight regime and provide more granular oversight of
-   MDAs.
+    5. Regulations should focus on equal and open access to digital asset
+       trading for all market participants — retail and institutional.
 
-    1. All registered MDAs should be required to be members of the SRO.
+    6. A dedicated self-regulatory organization (**"_SRO"_**) should be
+       established to strengthen the oversight regime and provide more granular
+       oversight of MDAs.
 
-    2. The SRO should establish the self-certification process that an MDA would
-        use to make a digital asset available for trading on its platform.
+        1. All registered MDAs should be required to be members of the SRO.
 
-7. The framework would preempt state-by-state registration and related
-   regulatory requirements.
+        2. The SRO should establish the self-certification process that an MDA
+            would use to make a digital asset available for trading on its
+            platform.
 
-8. The treatment of platforms and services that do not custody or otherwise
-   control the assets of a customer would need to be inherently different from
-   an MDA that holds and controls customer assets, and is therefore not
-   addressed by this framework.
+    7. The framework would preempt state-by-state registration and related
+       regulatory requirements.
 
-## New Framework Should Be Guided by Three Goals
+    8. The treatment of platforms and services that do not custody or otherwise
+       control the assets of a customer would need to be inherently different
+       from an MDA that holds and controls customer assets, and is therefore not
+       addressed by this framework.
 
-### Enhance transparency through appropriate disclosure requirements
+6. ### Promote Interoperability and Fair Competition
+
+    1. MDAs must be interoperable with products and services across the
+       cryptoeconomy.
+
+    2. The new regulatory framework should encourage communication, competition
+       and cross-pollination among protocols, applications, and MDAs.
+
+## Framework Goals
+
+1. ### Enhance transparency through appropriate disclosure requirements
 
    1. The information environment for digital assets should focus on the
       material characteristics, benefits, and risks of the asset itself. An
@@ -100,7 +111,7 @@ framework, or the framework as a whole, using GitHub. You will find it here:
          process for obtaining timely, case-specific, interpretive, or exemptive
          relief.
 
-### Protect against fraud and market manipulation
+2. ### Protect against fraud and market manipulation
 
    1. An MDA would need to make available required disclosures about the digital
       assets it supports.
@@ -114,7 +125,11 @@ framework, or the framework as a whole, using GitHub. You will find it here:
    4. MDAs should provide clear information about their operations to the
       public.
 
-### Promote efficiency and strengthen market resiliency
+3. ### Promote efficiency and strengthen market resiliency
+
+    Each of the goals should be accomplished in recognition of the unique
+    characteristics and risks of the underlying functionalities of digital
+    assets.
 
    1. Rules for MDAs should account for market participants having direct access
       to exchange services, and not through broker-dealers as gatekeepers.
@@ -142,15 +157,3 @@ framework, or the framework as a whole, using GitHub. You will find it here:
 
    7. MDAs must also consider and address risks arising from the role played by
       market-makers and other liquidity providers on their trading venues.
-
-4. Each of the goals should be accomplished in recognition of the unique
-   characteristics and risks of the underlying functionalities of digital
-   assets.
-
-## Promote Interoperability and Fair Competition
-
-1. MDAs must be interoperable with products and services across the
-   cryptoeconomy.
-
-2. The new regulatory framework should encourage communication, competition and
-   cross-pollination among protocols, applications, and MDAs.


### PR DESCRIPTION
The actual language is not modified, but the document was reorganized and formatted for clarification for ease of access. Some changes:

- Added table of contents (with `doctoc`)
- Separated goals into own section, moved to bottom
- Enumerated headings
- Split into sections: **Framework** and **Goals**

This was forked off of #2 for easier review. That PR can be closed if this one is merged directly.